### PR TITLE
Change of codes that do not work

### DIFF
--- a/Blavaan/Blavaan Jags Regression.Rmd
+++ b/Blavaan/Blavaan Jags Regression.Rmd
@@ -516,7 +516,7 @@ _The results change with different prior specifications, but are still comparabl
 
 ```{r,eval=FALSE}
 indices   <- sample.int(333, 60)
-smalldata <- data[indices,]
+smalldata <- dataPHD[indices,]
 ```
 
 _We made a new dataset with randomly chosen 60 of the 333 observations from the original dataset. You can repeat the analyses with the same code and only changing the name of the dataset to see the influence of priors on a smaller dataset. Run the model model.informative.priors2 with this new dataset_ 


### PR DESCRIPTION
Below codes do not work.
Error message: Error in data[indices, ] : object of type 'closure' is not subsettable

indices   <- sample.int(333, 60)
smalldata <- data[indices,]
fit.bayes.infprior2_small <- blavaan(model = model.informative.priors2, data = smalldata, convergence = "auto",  target = "jags",  test = "none", seed = c(12,34,56))
summary(fit.bayes.infprior2_small, fit.measures=TRUE, ci = TRUE, rsquare=TRUE)

If I change from data to dataPHD, it works.