### PR TITLE
Fix LinkedIn reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Citable versions of the tutorials are available at [Zenodo](https://zenodo.org/c
 
 # Contact
 
-If you want to be the first to be informed about updates, follow me on [Twitter](https://twitter.com/RensvdSchoot) or [LinkedIn](https://www.linkedin.com/in/rensvandeschoot).
+If you want to be the first to be informed about updates, follow me on [Twitter](https://twitter.com/RensvdSchoot) or [LinkedIn](https://www.linkedin.com/in/rensvandeschoot/).

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Citable versions of the tutorials are available at [Zenodo](https://zenodo.org/c
 
 # Contact
 
-If you want to be the first to be informed about updates, follow me on [Twitter](https://twitter.com/RensvdSchoot) or [LinkedIn](https://www.linkedin.com/rensvandeschoot/).
+If you want to be the first to be informed about updates, follow me on [Twitter](https://twitter.com/RensvdSchoot) or [LinkedIn](https://www.linkedin.com/in/rensvandeschoot).


### PR DESCRIPTION
Apparently, LinkedIn changed their URL structure. The current link leads to an error site, this pull request fixes this